### PR TITLE
Add uv package management for Python tools

### DIFF
--- a/python/install.sh
+++ b/python/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Install Python tools via uv
+#
+
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "uv is not installed. Please install it first (brew install uv)"
+    exit 1
+fi
+
+# Get the dotfiles root directory
+DOTFILES_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+
+# Install tools from uv.reqs if it exists
+if [ -f "$DOTFILES_ROOT/uv.reqs" ]; then
+    echo "› Installing Python tools from uv.reqs"
+    
+    while IFS= read -r tool || [ -n "$tool" ]; do
+        # Skip empty lines and comments
+        if [ -z "$tool" ] || [[ "$tool" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+        
+        # Trim whitespace
+        tool=$(echo "$tool" | xargs)
+        
+        echo "  Installing $tool..."
+        if uv tool install "$tool" --quiet; then
+            echo "  ✓ $tool installed"
+        else
+            echo "  ✗ Failed to install $tool"
+        fi
+    done < "$DOTFILES_ROOT/uv.reqs"
+    
+    echo "› Python tools installation complete"
+else
+    echo "› No uv.reqs file found, skipping Python tools installation"
+fi

--- a/python/path.zsh
+++ b/python/path.zsh
@@ -1,0 +1,2 @@
+# Add ~/.local/bin to PATH for uv-installed tools
+export PATH="$HOME/.local/bin:$PATH"

--- a/uv.reqs
+++ b/uv.reqs
@@ -1,0 +1,4 @@
+# UV tools to install
+# Add Python tools here, one per line
+# Format: package or package[extras]
+basic-memory


### PR DESCRIPTION
- Create uv.reqs file to track Python tools installed via uv
- Add python/install.sh to automatically install tools from uv.reqs
- Add python/path.zsh to include ~/.local/bin in PATH for uv-installed tools
- Integrates with existing dotfiles install/update workflow via script/install

🤖 Generated with [Claude Code](https://claude.ai/code)