### PR TITLE
feat(surf): add browser lane wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ dot -e       # Open dotfiles in editor
 | **AI Coding** | Claude Code, OpenCode, Gemini CLI, Codex, Pi |
 | **Window Mgmt** | AeroSpace (i3-like tiling), Ice (menu bar) |
 | **Database** | PostgreSQL 17, Redis |
-| **CLI Tools** | fzf, eza, bat, ripgrep, fd, jq, httpie, ast-grep, zoxide, shellcheck, just, agent-browser |
+| **CLI Tools** | fzf, eza, bat, ripgrep, fd, jq, httpie, ast-grep, zoxide, shellcheck, just, agent-browser, surf-cli |
 
 ## Architecture
 
@@ -53,6 +53,7 @@ Each directory is a self-contained "topic" managing one tool or concern:
 | `mise/` | mise-managed runtimes and native Node CLIs such as QMD |
 | `pi/` | Pi coding agent config, extensions |
 | `agent-browser/` | Headless browser automation for AI agents |
+| `surf/` | Surf browser lanes for reliable Brave/Edge agent control |
 | `ripgrep/` | Ripgrep config and environment setup |
 | `python/` | Python tools via uv |
 | `ruby/` | Ruby config (gemrc, irbrc) |

--- a/ai/skills/surf-browser/SKILL.md
+++ b/ai/skills/surf-browser/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: surf-browser
+description: Use for browser automation in this dotfiles setup, especially real logged-in browsing. Use surf-brave for the default Brave browser and surf-edge for work/Edge. Use agent-browser only for headless or isolated test automation.
+---
+
+# Surf Browser
+
+Use Surf when an agent needs to inspect, click through, screenshot, or read a real browser page using the user's logged-in browser state.
+
+## Browser lanes
+
+This dotfiles setup uses per-browser sockets:
+
+| Situation | Command | Browser |
+|---|---|---|
+| Default agent browsing | `surf-brave` | Brave (`surf`, dedicated user data) |
+| Work / corporate / Edge-specific browsing | `surf-edge` | Microsoft Edge |
+
+The wrappers set `SURF_SOCKET` so Brave and Edge do not compete for Surf's default `/tmp/surf.sock`. The Brave wrapper opens isolated `surf` user data and its managed extension copy directly, outside Brave's normal profile picker. Keep Surf disabled in the human-only `muke` profile. Use `~/.dotfiles/surf/install.sh` for native-host setup.
+
+## Start every task safely
+
+1. Pick the lane:
+   - Default to `surf-brave` for isolated agent browsing.
+   - Use `surf-edge` when the user says work, corporate, Microsoft, Edge, Entra/Azure, SharePoint, Outlook, Teams, or similar.
+2. Check connectivity:
+   ```bash
+   surf-brave tab.list
+   # or
+   surf-edge tab.list
+   ```
+3. Create an isolated work window before acting:
+   ```bash
+   surf-brave window.new --unfocused
+   # Retain the returned tab ID, then navigate that tab explicitly.
+   surf-brave go "https://example.com" --tab-id <tab-id>
+   surf-brave tab.name agent-task --tab-id <tab-id>
+   ```
+4. Retain the returned window/tab IDs and target them explicitly on follow-up commands. Avoid `tab.switch` and `window.focus` unless the task requires visible focus.
+
+## Common commands
+
+```bash
+surf-brave go "https://example.com" --tab-id <tab-id>
+surf-brave read --depth 3 --compact --tab-id <tab-id>
+surf-brave locate.role button --name "Submit" --action click --tab-id <tab-id>
+surf-brave locate.label "Email" --action fill --value "user@example.com" --tab-id <tab-id>
+surf-brave screenshot --annotate --tab-id <tab-id>
+surf-brave network --exclude-static --tab-id <tab-id>
+surf-brave console --tab-id <tab-id>
+```
+
+Swap `surf-edge` for `surf-brave` on work/Edge tasks.
+
+## When Surf is the wrong tool
+
+- For public web search or factual lookup, use search/extract tools instead of driving a browser.
+- For headless, CI-like, cloud, iOS, React/vitals, video, or heavily isolated automation, prefer `agent-browser`.
+- For local app visual QA, Surf is useful only if the app is served in Brave/Edge and login/session reuse matters.
+
+## Troubleshooting
+
+If a lane reports socket errors:
+
+1. Make sure the browser is open and the Surf extension is enabled.
+2. Restart that browser after native-host changes.
+3. Run the dotfiles installer:
+   ```bash
+   ~/.dotfiles/surf/install.sh
+   ```
+4. If extension ID auto-detection fails, load the extension from `surf-brave extension-path`, copy the ID from the browser extensions page, then run:
+   ```bash
+   SURF_BRAVE_EXTENSION_ID=<id> ~/.dotfiles/surf/install.sh
+   SURF_EDGE_EXTENSION_ID=<id> ~/.dotfiles/surf/install.sh
+   ```

--- a/bin/dot-doctor
+++ b/bin/dot-doctor
@@ -144,6 +144,113 @@ else
   info "Install: brew install yt-dlp"
 fi
 
+# ── Surf browser lanes ─────────────────────────────────────────
+
+header "Surf browser lanes"
+
+for wrapper in surf surf-brave surf-edge; do
+  if [ -x "$DOTFILES_ROOT/bin/$wrapper" ]; then
+    pass "$wrapper wrapper"
+  else
+    fail "$wrapper wrapper missing"
+    info "Fix: restore $DOTFILES_ROOT/bin/$wrapper"
+  fi
+done
+
+surf_node_version="$(awk -F= '/^[[:space:]]*node[[:space:]]*=/{gsub(/[ \"'"'"']/, "", $2); print $2; exit}' "$DOTFILES_ROOT/mise.toml")"
+surf_mise_bin=""
+if command -v mise >/dev/null 2>&1 && [ -n "$surf_node_version" ]; then
+  surf_mise_prefix="$(mise exec -C "$DOTFILES_ROOT" "node@$surf_node_version" -- npm prefix -g 2>/dev/null || true)"
+  if [ -n "$surf_mise_prefix" ]; then
+    surf_mise_bin="$surf_mise_prefix/bin/surf"
+  fi
+fi
+
+if [ -n "$surf_mise_bin" ] && [ -x "$surf_mise_bin" ]; then
+  pass "surf-cli mise runtime binary: $surf_mise_bin"
+else
+  warn "surf-cli is not installed under the mise-managed Node runtime"
+  info "Fix: run $DOTFILES_ROOT/mise/install.sh"
+fi
+
+check_surf_manifest() {
+  lane_label="$1"
+  manifest_path="$2"
+  expected_socket="$3"
+
+  if [ ! -f "$manifest_path" ]; then
+    warn "$lane_label Surf native host manifest not installed"
+    info "Fix: load Surf extension in $lane_label, then run $DOTFILES_ROOT/surf/install.sh"
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "$lane_label Surf native host manifest could not be validated (jq missing)"
+    return
+  fi
+
+  if ! jq -e '
+    .name == "surf.browser.host" and
+    .type == "stdio" and
+    (.path | type == "string" and length > 0) and
+    (.allowed_origins | type == "array" and length > 0 and all(.[]; test("^chrome-extension://[a-p]{32}/$")))
+  ' "$manifest_path" >/dev/null 2>&1; then
+    fail "$lane_label Surf native host manifest is invalid"
+    info "Fix: rerun $DOTFILES_ROOT/surf/install.sh"
+    return
+  fi
+
+  pass "$lane_label Surf native host manifest"
+
+  surf_host_wrapper="$(jq -r '.path' "$manifest_path")"
+  if [ -x "$surf_host_wrapper" ]; then
+    pass "$lane_label Surf native host wrapper"
+  else
+    fail "$lane_label Surf native host wrapper is missing or not executable"
+    info "Expected wrapper: $surf_host_wrapper"
+    info "Fix: rerun $DOTFILES_ROOT/surf/install.sh"
+    return
+  fi
+
+  if grep -Fq "SURF_SOCKET=\"$expected_socket\"" "$surf_host_wrapper"; then
+    pass "$lane_label Surf socket configuration"
+  else
+    fail "$lane_label Surf native host does not target $expected_socket"
+    info "Fix: rerun $DOTFILES_ROOT/surf/install.sh"
+  fi
+
+  if [ ! -S "$expected_socket" ]; then
+    warn "$lane_label Surf runtime is not ready (socket absent: $expected_socket)"
+    info "Open $lane_label with the Surf extension enabled, then rerun dot doctor"
+  elif mise exec -C "$DOTFILES_ROOT" "node@$surf_node_version" -- node -e '
+    const net = require("node:net");
+    const socket = net.createConnection(process.argv[1]);
+    const done = (status) => { socket.destroy(); process.exit(status); };
+    socket.setTimeout(250, () => done(1));
+    socket.once("connect", () => done(0));
+    socket.once("error", () => done(1));
+  ' "$expected_socket" >/dev/null 2>&1; then
+    pass "$lane_label Surf runtime socket"
+  else
+    fail "$lane_label Surf runtime socket exists but is not accepting connections"
+    info "Restart $lane_label with the Surf extension enabled, then rerun dot doctor"
+  fi
+}
+
+case "$(uname -s)" in
+  Darwin)
+    check_surf_manifest "Brave" "$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts/surf.browser.host.json" "/tmp/surf-brave.sock"
+    check_surf_manifest "Microsoft Edge" "$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts/surf.browser.host.json" "/tmp/surf-edge.sock"
+    ;;
+  Linux)
+    check_surf_manifest "Brave" "$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts/surf.browser.host.json" "/tmp/surf-brave.sock"
+    check_surf_manifest "Microsoft Edge" "$HOME/.config/microsoft-edge/NativeMessagingHosts/surf.browser.host.json" "/tmp/surf-edge.sock"
+    ;;
+  *)
+    warn "Surf lane manifest checks are only implemented for macOS and Linux"
+    ;;
+esac
+
 # ── Top-level symlinks ─────────────────────────────────────────
 
 header "Top-level symlinks"

--- a/bin/surf
+++ b/bin/surf
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Dotfiles policy wrapper: plain `surf` targets the default Brave lane.
+# Use surf-edge for Microsoft Edge, and surf/install.sh for native-host setup.
+
+set -euo pipefail
+
+DOTFILES_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+
+case "${1:-}" in
+  install|uninstall)
+    echo "This dotfiles setup manages Surf native hosts with per-browser sockets." >&2
+    echo "Use: $DOTFILES_ROOT/surf/install.sh" >&2
+    echo "For browser control, use surf (Brave default), surf-brave, or surf-edge." >&2
+    exit 64
+    ;;
+esac
+
+exec "$DOTFILES_ROOT/surf/bin/surf-lane" brave "$@"

--- a/bin/surf-brave
+++ b/bin/surf-brave
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Surf lane for the user's default personal browser (Brave).
+
+set -euo pipefail
+
+DOTFILES_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+exec "$DOTFILES_ROOT/surf/bin/surf-lane" brave "$@"

--- a/bin/surf-edge
+++ b/bin/surf-edge
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Surf lane for work/corporate browsing in Microsoft Edge.
+
+set -euo pipefail
+
+DOTFILES_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+exec "$DOTFILES_ROOT/surf/bin/surf-lane" edge "$@"

--- a/mise/node-globals.reqs
+++ b/mise/node-globals.reqs
@@ -2,3 +2,5 @@
 # Use this for npm CLIs with native Node dependencies or Node ABI sensitivity.
 # Keep simple Bun-friendly JS CLIs in ../bun.reqs instead.
 @tobilu/qmd@2.5.3
+# Surf uses a Chrome native-messaging host; keep its internal host layout stable.
+surf-cli@2.8.0

--- a/surf/README.md
+++ b/surf/README.md
@@ -1,0 +1,48 @@
+# Surf browser lanes
+
+Surf controls real Chromium browsers through an extension + native host. This setup keeps Brave and Edge on separate sockets so agents do not accidentally drive the wrong browser.
+
+| Lane | Browser | Socket | Command |
+|---|---|---|---|
+| Personal agent | Brave (`surf`, dedicated user data) | `/tmp/surf-brave.sock` | `surf-brave ...` |
+| Work | Microsoft Edge | `/tmp/surf-edge.sock` | `surf-edge ...` |
+
+## Install / repair
+
+1. Install npm globals:
+
+   ```sh
+   ~/.dotfiles/mise/install.sh
+   ```
+
+2. Prepare Surf's managed extension and native hosts:
+
+   ```sh
+   ~/.dotfiles/surf/install.sh
+   ```
+
+   - On the first Brave setup, run `surf-brave tab.list` once to create the isolated browser data and load the extension. The command may report a missing socket.
+   - Rerun `~/.dotfiles/surf/install.sh`, restart the `surf` browser instance, and test again.
+   - The `surf` instance does not appear in the normal Brave profile picker. Do not enable Surf in `muke`.
+   - Edge: open `edge://extensions`, enable Developer Mode, Load unpacked, choose the printed path.
+
+   The installer auto-detects the Surf extension ID from browser profile preferences. If detection fails after the first-run sequence, copy the extension ID from the browser extensions page and rerun with an override:
+
+   ```sh
+   SURF_BRAVE_EXTENSION_ID=<id> ~/.dotfiles/surf/install.sh
+   SURF_EDGE_EXTENSION_ID=<id> ~/.dotfiles/surf/install.sh
+   ```
+
+3. Restart any browser whose native host was updated, then test:
+
+   ```sh
+   surf-brave tab.list
+   surf-edge tab.list
+   ```
+
+## Usage rules
+
+- Use `surf-brave` for agent browsing. It opens isolated user data under `surf-cli-dotfiles`; normal Brave continues to open `muke`.
+- Use `surf-edge` for work/corporate sites or when the user explicitly asks for Edge.
+- Avoid `surf install`; upstream writes Surf's default single-socket host. Use `surf/install.sh` instead.
+- Prefer `window.new --unfocused` without a URL, retain its returned IDs, then navigate with `go <url> --tab-id <tab-id>`. This avoids a background content-script startup race. Pass `--window-id` or `--tab-id` on later commands.

--- a/surf/bin/surf-lane
+++ b/surf/bin/surf-lane
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Run surf-cli against a specific browser lane/socket.
+# This prevents Brave and Edge from competing for Surf's default /tmp/surf.sock.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: surf-lane <brave|edge> [surf args...]" >&2
+  exit 64
+fi
+
+lane="$1"
+shift
+
+case "$lane" in
+  brave)
+    socket="/tmp/surf-brave.sock"
+    browser_app="Brave Browser"
+    browser_profile="Default"
+    ;;
+  edge)
+    socket="/tmp/surf-edge.sock"
+    browser_app="Microsoft Edge"
+    browser_profile="Default"
+    ;;
+  *)
+    echo "Unknown Surf lane: $lane" >&2
+    echo "Expected: brave or edge" >&2
+    exit 64
+    ;;
+esac
+
+DOTFILES_ROOT="$(cd "$(dirname "$0")/../.." && pwd -P)"
+NODE_VERSION="$(awk -F= '/^[[:space:]]*node[[:space:]]*=/{gsub(/[ \"'"'"']/, "", $2); print $2; exit}' "$DOTFILES_ROOT/mise.toml")"
+
+find_surf_bin() {
+  if command -v mise >/dev/null 2>&1 && [ -n "$NODE_VERSION" ]; then
+    local npm_prefix
+    npm_prefix="$(mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- npm prefix -g 2>/dev/null || true)"
+    if [ -n "$npm_prefix" ] && [ -x "$npm_prefix/bin/surf" ]; then
+      printf '%s\n' "$npm_prefix/bin/surf"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+surf_bin="$(find_surf_bin || true)"
+if [ -z "$surf_bin" ] || [ ! -x "$surf_bin" ]; then
+  echo "surf-cli is not installed under the mise-managed Node runtime." >&2
+  echo "Fix: run ~/.dotfiles/mise/install.sh or dot" >&2
+  exit 127
+fi
+
+managed_extension_path=""
+browser_user_data=""
+if [ "$lane" = "brave" ]; then
+  case "$(uname -s)" in
+    Darwin)
+      managed_extension_path="$HOME/Library/Application Support/surf-cli-dotfiles/brave-agent-extension"
+      browser_user_data="$HOME/Library/Application Support/surf-cli-dotfiles/brave-user-data"
+      ;;
+    Linux)
+      managed_extension_path="$HOME/.local/share/surf-cli-dotfiles/brave-agent-extension"
+      browser_user_data="$HOME/.local/share/surf-cli-dotfiles/brave-user-data"
+      ;;
+  esac
+fi
+
+if [ "${1:-}" = "extension-path" ] && [ -n "$managed_extension_path" ]; then
+  printf '%s\n' "$managed_extension_path"
+  exit 0
+fi
+
+socket_ready() {
+  mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- node -e '
+    const net = require("node:net");
+    const socket = net.createConnection(process.argv[1]);
+    const done = (status) => { socket.destroy(); process.exit(status); };
+    socket.setTimeout(250, () => done(1));
+    socket.once("connect", () => done(0));
+    socket.once("error", () => done(1));
+  ' "$SURF_SOCKET" >/dev/null 2>&1
+}
+
+case "${1:-}" in
+  install|uninstall)
+    echo "This dotfiles setup manages Surf native hosts with per-browser sockets." >&2
+    echo "Use: $DOTFILES_ROOT/surf/install.sh" >&2
+    echo "For browser control, use surf (Brave default), surf-brave, or surf-edge." >&2
+    exit 64
+    ;;
+esac
+
+needs_socket=true
+case "${1:-}" in
+  ""|-h|--help|--help-full|--help-topic|--find|--llm-context|-V|--version|extension-path|path)
+    needs_socket=false
+    ;;
+esac
+
+export SURF_SOCKET="$socket"
+
+# On macOS, open the profile that owns the Surf extension if its lane socket is
+# unavailable. Calling the app without a profile can stop at the profile picker,
+# where no extension or native host is loaded.
+if [ "$needs_socket" = true ] && [ "$(uname -s)" = "Darwin" ] && ! socket_ready; then
+  browser_binary="/Applications/$browser_app.app/Contents/MacOS/$browser_app"
+  if [ -x "$browser_binary" ]; then
+    browser_args=(--profile-directory="$browser_profile")
+    if [ -n "$browser_user_data" ]; then
+      browser_args+=(--user-data-dir="$browser_user_data")
+    fi
+    if [ -n "$managed_extension_path" ] && [ -d "$managed_extension_path" ]; then
+      browser_args+=(--load-extension="$managed_extension_path")
+    fi
+    "$browser_binary" "${browser_args[@]}" >/dev/null 2>&1 &
+  else
+    open -g -a "$browser_app" --args --profile-directory="$browser_profile" >/dev/null 2>&1 || true
+  fi
+  deadline=$((SECONDS + 15))
+  while ! socket_ready && [ "$SECONDS" -lt "$deadline" ]; do
+    sleep 0.2
+  done
+fi
+
+exec mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- "$surf_bin" "$@"

--- a/surf/install.sh
+++ b/surf/install.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+#
+# Install Surf browser lane native hosts.
+#
+# This dotfiles setup intentionally avoids Surf's single default /tmp/surf.sock.
+# Brave and Edge get separate native-host wrappers and sockets so agents target
+# the intended browser consistently.
+
+set -euo pipefail
+
+DOTFILES_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+
+# shellcheck source=../lib/log.sh
+. "$DOTFILES_ROOT/lib/log.sh"
+
+NODE_VERSION="$(awk -F= '/^[[:space:]]*node[[:space:]]*=/{gsub(/[ \"'"'"']/, "", $2); print $2; exit}' "$DOTFILES_ROOT/mise.toml")"
+
+if ! command -v mise >/dev/null 2>&1; then
+  log_warn "mise is not installed; skipping Surf lane setup"
+  log_hint "Fix: run homebrew/install.sh or brew install mise"
+  exit 0
+fi
+
+if [ -z "$NODE_VERSION" ]; then
+  log_warn "No Node version found in mise.toml; skipping Surf lane setup"
+  exit 0
+fi
+
+NODE_PATH="$(mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- which node 2>/dev/null || true)"
+NPM_PREFIX="$(mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- npm prefix -g 2>/dev/null || true)"
+NPM_ROOT="$(mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- npm root -g 2>/dev/null || true)"
+
+if [ -z "$NODE_PATH" ] || [ ! -x "$NODE_PATH" ]; then
+  log_warn "Could not find mise-managed Node; skipping Surf lane setup"
+  log_hint "Fix: run $DOTFILES_ROOT/mise/install.sh"
+  exit 0
+fi
+
+SURF_BIN="$NPM_PREFIX/bin/surf"
+SURF_ROOT="$NPM_ROOT/surf-cli"
+SURF_HOST="$SURF_ROOT/native/host.cjs"
+SURF_SOCKET_MODULE="$SURF_ROOT/native/socket-path.cjs"
+
+if [ -z "$NPM_PREFIX" ] || [ ! -x "$SURF_BIN" ] || [ ! -f "$SURF_HOST" ]; then
+  log_warn "surf-cli is not installed under mise-managed Node; skipping Surf lane setup"
+  log_hint "Fix: run $DOTFILES_ROOT/mise/install.sh"
+  exit 0
+fi
+
+if [ ! -f "$SURF_SOCKET_MODULE" ] || ! grep -Fq 'process.env.SURF_SOCKET' "$SURF_SOCKET_MODULE"; then
+  log_error "Installed surf-cli does not provide the required SURF_SOCKET interface"
+  log_hint "Expected: $SURF_SOCKET_MODULE"
+  log_hint "Fix: install the pinned surf-cli version with $DOTFILES_ROOT/mise/install.sh"
+  exit 1
+fi
+
+EXTENSION_PATH="$(mise exec -C "$DOTFILES_ROOT" "node@$NODE_VERSION" -- "$SURF_BIN" extension-path 2>/dev/null || true)"
+if [ -z "$EXTENSION_PATH" ] || [ ! -d "$EXTENSION_PATH" ]; then
+  log_warn "Could not determine Surf extension path"
+  log_hint "Command failed: $SURF_BIN extension-path"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    WRAPPER_DIR="$HOME/Library/Application Support/surf-cli-dotfiles"
+    # Brave's macOS build resolves user-level native hosts through Chromium's
+    # Google Chrome path, even though its profile data lives under BraveSoftware.
+    brave_manifest_dir="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    brave_extension_path="$WRAPPER_DIR/brave-agent-extension"
+    brave_user_data_dir="$WRAPPER_DIR/brave-user-data"
+    edge_manifest_dir="$HOME/Library/Application Support/Microsoft Edge/NativeMessagingHosts"
+    ;;
+  Linux)
+    WRAPPER_DIR="$HOME/.local/share/surf-cli-dotfiles"
+    brave_manifest_dir="$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
+    brave_extension_path="$WRAPPER_DIR/brave-agent-extension"
+    brave_user_data_dir="$WRAPPER_DIR/brave-user-data"
+    edge_manifest_dir="$HOME/.config/microsoft-edge/NativeMessagingHosts"
+    ;;
+  *)
+    log_warn "Surf lane setup is only implemented for macOS and Linux"
+    exit 0
+    ;;
+esac
+
+sync_managed_extension() {
+  local source="$1"
+  local destination="$2"
+
+  "$NODE_PATH" - "$source" "$destination" <<'NODE'
+const fs = require('node:fs');
+const [source, destination] = process.argv.slice(2);
+fs.rmSync(destination, { recursive: true, force: true });
+fs.cpSync(source, destination, { recursive: true });
+NODE
+}
+
+sync_managed_extension "$EXTENSION_PATH" "$brave_extension_path"
+log_success "Updated managed Brave agent extension"
+log_hint "Extension path: $brave_extension_path"
+
+write_wrapper() {
+  local lane="$1"
+  local socket="$2"
+  local wrapper="$WRAPPER_DIR/$lane-host-wrapper.sh"
+
+  mkdir -p "$WRAPPER_DIR"
+  cat > "$wrapper" <<EOF
+#!/usr/bin/env bash
+set -e
+export SURF_SOCKET="$socket"
+if [ "\${SURF_WRAPPER_DEBUG:-}" = "1" ]; then
+  printf '%s %s %s\n' "\$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$lane" "$socket" >> /tmp/surf-native-host-wrapper.log
+fi
+cd "$(dirname "$SURF_HOST")"
+exec "$NODE_PATH" "$SURF_HOST" "\$@"
+EOF
+  chmod 755 "$wrapper"
+  printf '%s\n' "$wrapper"
+}
+
+write_manifest() {
+  local manifest_dir="$1"
+  local extension_id="$2"
+  local wrapper="$3"
+  local label="$4"
+  local manifest_path="$manifest_dir/surf.browser.host.json"
+
+  mkdir -p "$manifest_dir"
+  cat > "$manifest_path" <<EOF
+{
+  "name": "surf.browser.host",
+  "description": "Surf CLI Native Host ($label lane, dotfiles managed)",
+  "path": "$wrapper",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://$extension_id/"
+  ]
+}
+EOF
+  log_success "Installed Surf native host for $label"
+  log_hint "Manifest: $manifest_path"
+}
+
+find_extension_id() {
+  local browser="$1"
+  local extension_path="$2"
+  local browser_root="$3"
+  local err_file="$4"
+
+  "$NODE_PATH" "$DOTFILES_ROOT/surf/scripts/find-extension-id.mjs" "$browser" "$extension_path" "$browser_root" 2>"$err_file"
+}
+
+install_lane() {
+  local browser="$1"
+  local label="$2"
+  local socket="$3"
+  local manifest_dir="$4"
+  local extension_path="$5"
+  local browser_root="$6"
+
+  local err_file
+  err_file="$(mktemp)"
+
+  local extension_id
+  if extension_id="$(find_extension_id "$browser" "$extension_path" "$browser_root" "$err_file")"; then
+    local wrapper
+    wrapper="$(write_wrapper "$browser" "$socket")"
+    write_manifest "$manifest_dir" "$extension_id" "$wrapper" "$label"
+    log_hint "CLI wrapper: surf-$browser (socket $socket)"
+  else
+    log_warn "Surf extension not found for $label; native host not installed"
+    while IFS= read -r line; do
+      [ -n "$line" ] && log_hint "$line"
+    done < "$err_file"
+    if [ "$browser" = "brave" ]; then
+      log_hint "First setup: run surf-brave tab.list once, then rerun this installer"
+    fi
+  fi
+
+  rm -f "$err_file"
+}
+
+log_info "Setting up Surf browser lanes"
+log_hint "Extension path: $EXTENSION_PATH"
+log_hint "Do not use 'surf install' for these lanes; this installer writes per-browser sockets."
+
+install_lane "brave" "Brave agent profile" "/tmp/surf-brave.sock" "$brave_manifest_dir" "$brave_extension_path" "$brave_user_data_dir"
+install_lane "edge" "Microsoft Edge" "/tmp/surf-edge.sock" "$edge_manifest_dir" "$EXTENSION_PATH" ""
+
+log_success "Surf lane setup complete"
+log_hint "Restart any browser whose native host was updated, then test with: surf-brave tab.list or surf-edge tab.list"

--- a/surf/scripts/find-extension-id.mjs
+++ b/surf/scripts/find-extension-id.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const browser = process.argv[2];
+const extensionPathArg = process.argv[3] || '';
+const browserRootArg = process.argv[4] || '';
+
+const browsers = {
+  brave: {
+    label: 'Brave',
+    env: 'SURF_BRAVE_EXTENSION_ID',
+    altEnv: 'SURF_EXTENSION_ID_BRAVE',
+    darwinRoot: ['Library', 'Application Support', 'BraveSoftware', 'Brave-Browser'],
+    linuxRoot: ['.config', 'BraveSoftware', 'Brave-Browser'],
+  },
+  edge: {
+    label: 'Microsoft Edge',
+    env: 'SURF_EDGE_EXTENSION_ID',
+    altEnv: 'SURF_EXTENSION_ID_EDGE',
+    darwinRoot: ['Library', 'Application Support', 'Microsoft Edge'],
+    linuxRoot: ['.config', 'microsoft-edge'],
+  },
+};
+
+const config = browsers[browser];
+if (!config) {
+  console.error('Usage: find-extension-id.mjs <brave|edge> [surf-extension-path] [browser-root]');
+  process.exit(64);
+}
+
+const extensionIdPattern = /^[a-p]{32}$/;
+
+function validateOverride(name, value) {
+  if (!value) return null;
+  if (!extensionIdPattern.test(value)) {
+    console.error(`${name} is not a valid Chromium extension ID: ${value}`);
+    process.exit(2);
+  }
+  return value;
+}
+
+const override =
+  validateOverride(config.env, process.env[config.env]) ||
+  validateOverride(config.altEnv, process.env[config.altEnv]);
+
+if (override) {
+  console.log(override);
+  process.exit(0);
+}
+
+function browserRoot() {
+  if (browserRootArg) return realish(browserRootArg);
+  const parts = process.platform === 'linux' ? config.linuxRoot : config.darwinRoot;
+  return path.join(os.homedir(), ...parts);
+}
+
+function realish(filePath) {
+  if (!filePath) return '';
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
+function comparable(filePath) {
+  const normalized = realish(filePath);
+  return process.platform === 'darwin' ? normalized.toLowerCase() : normalized;
+}
+
+const expectedExtensionPath = extensionPathArg ? comparable(extensionPathArg) : '';
+
+function pathMatchesSurf(setting) {
+  if (!expectedExtensionPath || !setting || !setting.path) return false;
+  return comparable(setting.path) === expectedExtensionPath;
+}
+
+function manifestLooksLikeSurf(manifest) {
+  if (!manifest || typeof manifest !== 'object') return false;
+
+  const name = String(manifest.name || manifest.short_name || '');
+  const description = String(manifest.description || '');
+
+  return (
+    name === 'Surf' ||
+    description.includes('Browser automation CLI for AI agents') ||
+    description.includes('AI agents to control Chrome')
+  );
+}
+
+function readJson(jsonPath) {
+  try {
+    return JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function collectFromPreferences(root) {
+  const candidates = [];
+  let entries = [];
+
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return candidates;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const profileDir = path.join(root, entry.name);
+    for (const prefName of ['Preferences', 'Secure Preferences']) {
+      const prefPath = path.join(profileDir, prefName);
+      if (!fs.existsSync(prefPath)) continue;
+
+      const prefs = readJson(prefPath);
+      const settings = prefs?.extensions?.settings;
+      if (!settings || typeof settings !== 'object') continue;
+
+      for (const [id, setting] of Object.entries(settings)) {
+        if (!extensionIdPattern.test(id)) continue;
+
+        const reasons = [];
+        if (pathMatchesSurf(setting)) reasons.push('path');
+        if (manifestLooksLikeSurf(setting?.manifest)) reasons.push('manifest');
+
+        if (reasons.length > 0) {
+          candidates.push({ id, profile: entry.name, source: prefName, reasons });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function collectFromInstalledExtensionManifests(root) {
+  const candidates = [];
+  let profiles = [];
+  try {
+    profiles = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return candidates;
+  }
+
+  for (const profileEntry of profiles) {
+    if (!profileEntry.isDirectory()) continue;
+
+    const extensionsRoot = path.join(root, profileEntry.name, 'Extensions');
+    let ids = [];
+    try {
+      ids = fs.readdirSync(extensionsRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const idEntry of ids) {
+      if (!idEntry.isDirectory() || !extensionIdPattern.test(idEntry.name)) continue;
+
+      const idDir = path.join(extensionsRoot, idEntry.name);
+      let versions = [];
+      try {
+        versions = fs.readdirSync(idDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      for (const versionEntry of versions) {
+        if (!versionEntry.isDirectory()) continue;
+        const manifest = readJson(path.join(idDir, versionEntry.name, 'manifest.json'));
+        if (manifestLooksLikeSurf(manifest)) {
+          candidates.push({
+            id: idEntry.name,
+            profile: profileEntry.name,
+            source: versionEntry.name,
+            reasons: ['installed-manifest'],
+          });
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+const root = browserRoot();
+let candidates = [
+  ...collectFromPreferences(root),
+  ...collectFromInstalledExtensionManifests(root),
+];
+
+const pathCandidates = candidates.filter((candidate) => candidate.reasons.includes('path'));
+if (pathCandidates.length > 0) candidates = pathCandidates;
+
+const byId = new Map();
+for (const candidate of candidates) {
+  if (!byId.has(candidate.id)) byId.set(candidate.id, []);
+  byId.get(candidate.id).push(candidate);
+}
+
+const ids = [...byId.keys()];
+
+if (ids.length === 1) {
+  console.log(ids[0]);
+  process.exit(0);
+}
+
+if (ids.length > 1) {
+  console.error(`Found multiple Surf extension IDs in ${config.label}; set ${config.env} explicitly.`);
+  for (const id of ids) {
+    const places = byId
+      .get(id)
+      .map((candidate) => `${candidate.profile}/${candidate.source}:${candidate.reasons.join('+')}`)
+      .join(', ');
+    console.error(`  ${id} (${places})`);
+  }
+  process.exit(3);
+}
+
+console.error(`Could not find the Surf extension ID in ${config.label}.`);
+if (extensionPathArg) {
+  console.error('Load the unpacked Surf extension from:');
+  console.error(`  ${extensionPathArg}`);
+}
+console.error(`Then rerun surf/install.sh, or set ${config.env}=<extension-id> for this run.`);
+process.exit(1);

--- a/surf/scripts/find-extension-id.test.mjs
+++ b/surf/scripts/find-extension-id.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const scriptPath = fileURLToPath(new URL('./find-extension-id.mjs', import.meta.url));
+
+test('finds a packaged extension inside a Chromium profile', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'surf-extension-id-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const browserRoot =
+    process.platform === 'linux'
+      ? path.join(home, '.config', 'BraveSoftware', 'Brave-Browser')
+      : path.join(home, 'Library', 'Application Support', 'BraveSoftware', 'Brave-Browser');
+  const extensionId = 'abcdefghijklmnopabcdefghijklmnop';
+  const extensionDir = path.join(browserRoot, 'Default', 'Extensions', extensionId, '2.8.0');
+
+  fs.mkdirSync(extensionDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(extensionDir, 'manifest.json'),
+    JSON.stringify({ name: 'Surf', description: 'Browser automation CLI for AI agents' }),
+  );
+
+  const result = execFileSync(process.execPath, [scriptPath, 'brave'], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  });
+
+  assert.equal(result.trim(), extensionId);
+});
+
+test('prefers the extension loaded from the requested path', (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'surf-extension-id-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const browserRoot = path.join(home, 'dedicated-brave-user-data');
+  const requestedPath = path.join(home, 'managed-surf-extension');
+  const oldId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const agentId = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  fs.mkdirSync(requestedPath, { recursive: true });
+  for (const [profile, id, extensionPath] of [
+    ['Default', oldId, path.join(home, 'old-surf-extension')],
+    ['Profile 1', agentId, requestedPath],
+  ]) {
+    const profileDir = path.join(browserRoot, profile);
+    fs.mkdirSync(profileDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(profileDir, 'Secure Preferences'),
+      JSON.stringify({
+        extensions: {
+          settings: {
+            [id]: {
+              path: extensionPath,
+              manifest: { name: 'Surf', description: 'Browser automation CLI for AI agents' },
+            },
+          },
+        },
+      }),
+    );
+  }
+
+  const result = execFileSync(process.execPath, [scriptPath, 'brave', requestedPath, browserRoot], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: home },
+  });
+
+  assert.equal(result.trim(), agentId);
+});


### PR DESCRIPTION
## Summary
- add Brave and Edge Surf lane wrappers with per-browser sockets
- install managed native-host manifests and Brave extension copy
- add Surf doctor checks, docs, and agent skill guidance

## Verification
- node --test surf/scripts/find-extension-id.test.mjs
- bash -n bin/surf bin/surf-brave bin/surf-edge surf/bin/surf-lane surf/install.sh bin/dot-doctor
- shellcheck bin/surf bin/surf-brave bin/surf-edge surf/bin/surf-lane surf/install.sh bin/dot-doctor
- dot doctor
- manual: surf-brave doctor/tab/read/screenshot flow and surf-edge still works